### PR TITLE
More secret id use options

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/entities/SecretIdUseOption.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/entities/SecretIdUseOption.kt
@@ -9,22 +9,54 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface SecretIdUseOption {
 	/**
-	 * This will use any secret id that is not known by any parent hcp of the current data owner. If the api is
-	 * initialized in a mode where the parent hcp keys are unused this will just mean "use any available secret id".
+	 * This will use any one secret id that is not known by any parent hcp of the current data owner.
+	 * If the api is initialized in a mode where the parent hcp keys are unused, this means "use any one available
+	 * secret id".
+	 * Guarantees that a secret id is used: if no secret id is found, the initialization method will fail.
 	 */
 	@Serializable
 	data object UseAnyConfidential : SecretIdUseOption
 
 	/**
-	 * This will use any secret id that is known by the topmost ancestor in the current data owner hierarchy. If the api
-	 * is initialized in a mode where the parent hcp keys are unused this will just mean "use any available secret id".
+	 * This will use all secret ids that aren't known by any parent hcp of the current data owner.
+	 * If the api is initialized in a mode where the parent hcp keys are unused, this means "use all available secret
+	 * id".
+	 * Guarantees that a secret id is used: if no secret id is found, the initialization method will fail.
+	 */
+	@Serializable
+	data object UseAllConfidential : SecretIdUseOption
+
+	/**
+	 * This will use one secret id that is known by the topmost ancestor in the current data owner hierarchy.
+	 * If the api is initialized in a mode where the parent hcp keys are unused, this means "use any one available
+	 * secret id".
+	 * Guarantees that a secret id is used: if no secret id is found, the initialization method will fail.
 	 */
 	@Serializable
 	data object UseAnySharedWithParent : SecretIdUseOption
 
 	/**
-	 * Specify explicitly which secret ids to use
+	 * This will use all secret id that is known by the topmost ancestor in the current data owner hierarchy.
+	 * If the api is initialized in a mode where the parent hcp keys are unused, this means "use all available secret
+	 * id".
+	 * Guarantees that a secret id is used: if no secret id is found, the initialization method will fail.
+	 */
+	@Serializable
+	data object UseAllSharedWithParent : SecretIdUseOption
+
+	/**
+	 * Specify explicitly which secret ids to use. The secretIds can also be empty, in which case the value is
+	 * equivalent to [UseNone].
+	 * Note that the SDK will not check that the secret id you used is actually a secret id of the owning entity.
 	 */
 	@Serializable
 	data class Use(val secretIds: Set<String>) : SecretIdUseOption
+
+	/**
+	 * Instructs the SDK to use no secret id of the owning entity.
+	 * The new entity will still have a link to the owning entity, but there will be no link from the owning entity to
+	 * the new entity.
+	 */
+	@Serializable
+	data object UseNone : SecretIdUseOption
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/EntityEncryptionServiceImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/crypto/impl/EntityEncryptionServiceImpl.kt
@@ -662,10 +662,27 @@ class EntityEncryptionServiceImpl(
 	override suspend fun resolveSecretIdOption(entity: EntityWithTypeInfo<*>, secretIdUseOption: SecretIdUseOption): Set<String> =
 		when (secretIdUseOption) {
 			is SecretIdUseOption.Use -> secretIdUseOption.secretIds
-			SecretIdUseOption.UseAnyConfidential -> getConfidentialSecretIdsOf(entity, null)
-			SecretIdUseOption.UseAnySharedWithParent -> getSecretIdsSharedWithParentsOf(entity)
-		}.also {
-			require(it.isNotEmpty()) { "No valid secret id found for option $secretIdUseOption" }
+			SecretIdUseOption.UseAnyConfidential -> getConfidentialSecretIdsOf(entity, null).also {
+				require(it.isNotEmpty()) {
+					"No valid secret id found for option $secretIdUseOption"
+				}
+			}.let { setOf(it.first()) }
+			SecretIdUseOption.UseAllConfidential -> getConfidentialSecretIdsOf(entity, null).also {
+				require(it.isNotEmpty()) {
+					"No valid secret id found for option $secretIdUseOption"
+				}
+			}
+			SecretIdUseOption.UseAnySharedWithParent -> getSecretIdsSharedWithParentsOf(entity).also {
+				require(it.isNotEmpty()) {
+					"No valid secret id found for option $secretIdUseOption"
+				}
+			}.let { setOf(it.first()) }
+			SecretIdUseOption.UseAllSharedWithParent -> getSecretIdsSharedWithParentsOf(entity).also {
+				require(it.isNotEmpty()) {
+					"No valid secret id found for option $secretIdUseOption"
+				}
+			}
+			SecretIdUseOption.UseNone -> emptySet()
 		}
 
 	private suspend fun dataOwnersForDecryption(startingFrom: String?) =


### PR DESCRIPTION
Add more secret id use options to support advanced use cases, including one-directional link to owning entity.