### PR TITLE
Remove regexes

### DIFF
--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ShamirKeysManagerApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/ShamirKeysManagerApiImpl.kt
@@ -1,12 +1,5 @@
 package com.icure.cardinal.sdk.api.impl
 
-import com.icure.kryptom.crypto.AesAlgorithm
-import com.icure.kryptom.crypto.AesKey
-import com.icure.kryptom.crypto.CryptoService
-import com.icure.kryptom.crypto.PrivateRsaKey
-import com.icure.kryptom.crypto.RsaAlgorithm
-import com.icure.kryptom.utils.hexToByteArray
-import com.icure.kryptom.utils.toHexString
 import com.icure.cardinal.sdk.api.DataOwnerApi
 import com.icure.cardinal.sdk.api.ShamirKeysManagerApi
 import com.icure.cardinal.sdk.crypto.ExchangeDataManager
@@ -19,8 +12,16 @@ import com.icure.cardinal.sdk.model.base.CryptoActor
 import com.icure.cardinal.sdk.model.extensions.asStub
 import com.icure.cardinal.sdk.model.specializations.HexString
 import com.icure.cardinal.sdk.model.specializations.KeypairFingerprintV1String
-import com.icure.utils.InternalIcureApi
 import com.icure.cardinal.sdk.utils.ensure
+import com.icure.cardinal.sdk.utils.isValidHex
+import com.icure.kryptom.crypto.AesAlgorithm
+import com.icure.kryptom.crypto.AesKey
+import com.icure.kryptom.crypto.CryptoService
+import com.icure.kryptom.crypto.PrivateRsaKey
+import com.icure.kryptom.crypto.RsaAlgorithm
+import com.icure.kryptom.utils.hexToByteArray
+import com.icure.kryptom.utils.toHexString
+import com.icure.utils.InternalIcureApi
 
 @InternalIcureApi
 class ShamirKeysManagerApiImpl(
@@ -105,7 +106,7 @@ class ShamirKeysManagerApiImpl(
 			val shares = shamir.share(keyPkcs8, request.notariesIds.size, request.minShares)
 			val paddedShares = shares.map { "f${it.v}" }
 			for (share in paddedShares) {
-				ensure(share.matches(Regex("^(?:[0-9a-f][0-9a-f])+$"))) {
+				ensure(share.isValidHex()) {
 					"Unexpected result of shamir split: padded shares should be a valid hex value"
 				}
 				ensure(share == hexToByteArray(share).toHexString()) {

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/serialization/ZonedDateTimeSerializer.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/serialization/ZonedDateTimeSerializer.kt
@@ -12,10 +12,10 @@ object ZonedDateTimeSerializer : KSerializer<ZonedDateTime> {
 	override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ZonedDateTime", PrimitiveKind.STRING)
 
 	override fun serialize(encoder: Encoder, value: ZonedDateTime) {
-		encoder.encodeString(value.toIso8601String())
+		encoder.encodeString(value.toIso8601AndZoneString())
 	}
 
 	override fun deserialize(decoder: Decoder): ZonedDateTime {
-		return ZonedDateTime.fromIso8601String(decoder.decodeString())
+		return ZonedDateTime.fromIso8601AndZoneString(decoder.decodeString())
 	}
 }

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/utils/Hex.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/utils/Hex.kt
@@ -1,0 +1,8 @@
+package com.icure.cardinal.sdk.utils
+
+private val DIGITS_RANGE = '0'.code .. '9'.code
+private val LOWERCASE_RANGE = 'a'.code .. 'f'.code
+private val UPPERCASE_RANGE = 'A'.code .. 'F'.code
+
+fun String.isValidHex() =
+	length % 2 == 0 && all { c -> c.code.let { it in DIGITS_RANGE || it in LOWERCASE_RANGE || it in UPPERCASE_RANGE }  }

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/utils/time/ZonedDateTimeTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/utils/time/ZonedDateTimeTest.kt
@@ -1,0 +1,44 @@
+package com.icure.cardinal.sdk.utils.time
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ZonedDateTimeTest : StringSpec({
+	"Full zoned date time test" {
+		listOf(
+			Triple("2025-02-24T15:07:01.564571","-05:00", "America/New_York"),
+			Triple("2025-02-24T15:07:01","Z", "UTC"),
+			Triple("2025-02-24T15:07:01.564571","+01:00", "UT+01:00"),
+		).forEach { (time, offset, zone) ->
+			val format = "$time$offset[$zone]"
+			val parsed = ZonedDateTime.fromIso8601AndZoneString(format)
+			parsed.toIso8601AndZoneString() shouldBe format
+		}
+	}
+
+	"Offset only zone test" {
+		listOf(
+			Pair("2025-02-24T15:06:08.886342","+01:00"),
+			Pair("2025-02-24T15:06:08.886342","-02:30"),
+			Pair("2025-02-24T12:00:01", "Z")
+		).forEach { (time, offset) ->
+			val format = "$time$offset"
+			val parsed = ZonedDateTime.fromIso8601AndZoneString(format)
+			parsed.toIso8601AndZoneString() shouldBe format
+			parsed.zoneId.id shouldBe offset
+		}
+	}
+
+	"Invalid input test" {
+		listOf(
+			"2025-02-24T12:00:12",
+			"2025-02-24T12:00:12UTC",
+			"2025-02-24T12:00:12-02:30[Europe/New_York]",
+			"[America/New_York]",
+			"-02:30",
+		).forEach {
+			shouldThrow<IllegalArgumentException> { ZonedDateTime.fromIso8601AndZoneString(it) }
+		}
+	}
+})

--- a/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/model/CheckedConverters.kt
+++ b/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/model/CheckedConverters.kt
@@ -202,7 +202,7 @@ object CheckedConverters {
 	fun zonedDateTimeToString(
 		zonedDateTime: ZonedDateTime,
 	): String {
-		return zonedDateTime.toIso8601String()
+		return zonedDateTime.toIso8601AndZoneString()
 	}
 
 	fun zonedDateTimeToString(
@@ -214,7 +214,7 @@ object CheckedConverters {
 		description: String
 	): ZonedDateTime {
 		return try {
-			ZonedDateTime.fromIso8601String(string)
+			ZonedDateTime.fromIso8601AndZoneString(string)
 		} catch (e: Exception) {
 			throw IllegalArgumentException("Invalid zoned date time $string @ $description", e)
 		}


### PR DESCRIPTION
[Some long regexes can cause stack overflow on kotlin native](https://youtrack.jetbrains.com/issue/KT-63689/Kotlin-Native-Stack-overflow-crash-in-Regex-classes-with-simple-pattern-and-very-large-input)

This PR replaces all usages of regexes in the SDK codebase with simpler checks.

Also includes fixes to the parsing of ZonedDateTime as the regex was flawed