### PR TITLE
feat: Added support for Patient as Document owning entity

### DIFF
--- a/cardinal-sdk/build.gradle.kts
+++ b/cardinal-sdk/build.gradle.kts
@@ -18,7 +18,7 @@ val mavenReleasesRepository: String by project
 
 group = "com.icure"
 
-val version = "2.0.0-PREVIEW-4"
+val version = "2.0.0-PREVIEW-5"
 project.version = version
 
 kotlin {

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/DocumentApi.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/DocumentApi.kt
@@ -368,13 +368,54 @@ interface DocumentApi : DocumentBasicFlavourlessApi, DocumentFlavouredApi<Decryp
 	 */
 	suspend fun withEncryptionMetadata(
 		base: DecryptedDocument?,
-		message: Message?,
+		message: Message,
 		@DefaultValue("null")
 		user: User? = null,
 		@DefaultValue("emptyMap()")
 		delegates: Map<String, AccessLevel> = emptyMap(),
 		@DefaultValue("com.icure.cardinal.sdk.crypto.entities.SecretIdUseOption.UseAnySharedWithParent")
 		secretId: SecretIdUseOption = SecretIdUseOption.UseAnySharedWithParent,
+	): DecryptedDocument
+
+	/**
+	 * Creates a new document with initialized encryption metadata
+	 * @param base a document with initialized content and uninitialized encryption metadata. The result of this
+	 * method takes the content from [base] if provided.
+	 * @param patient the patient linked to the patient, if any.
+	 * @param user the current user, will be used for the auto-delegations if provided.
+	 * @param delegates additional data owners that will have access to the newly created entity. You may choose the
+	 * permissions that the delegates will have on the entity, but they will have access to all encryption metadata.
+	 * @param secretId specifies which secret id of [message] to use for the new document
+	 * @return a document with initialized encryption metadata.
+	 * @throws IllegalArgumentException if base is not null and has a revision or has encryption metadata.
+	 */
+	suspend fun withEncryptionMetadata(
+		base: DecryptedDocument?,
+		patient: Patient,
+		@DefaultValue("null")
+		user: User? = null,
+		@DefaultValue("emptyMap()")
+		delegates: Map<String, AccessLevel> = emptyMap(),
+		@DefaultValue("com.icure.cardinal.sdk.crypto.entities.SecretIdUseOption.UseAnySharedWithParent")
+		secretId: SecretIdUseOption = SecretIdUseOption.UseAnySharedWithParent,
+	): DecryptedDocument
+
+	/**
+	 * Creates a new document with initialized encryption metadata
+	 * @param base a document with initialized content and uninitialized encryption metadata. The result of this
+	 * method takes the content from [base] if provided.
+	 * @param user the current user, will be used for the auto-delegations if provided.
+	 * @param delegates additional data owners that will have access to the newly created entity. You may choose the
+	 * permissions that the delegates will have on the entity, but they will have access to all encryption metadata.
+	 * @return a document with initialized encryption metadata.
+	 * @throws IllegalArgumentException if base is not null and has a revision or has encryption metadata.
+	 */
+	suspend fun withEncryptionMetadata(
+		base: DecryptedDocument?,
+		@DefaultValue("null")
+		user: User? = null,
+		@DefaultValue("emptyMap()")
+		delegates: Map<String, AccessLevel> = emptyMap(),
 	): DecryptedDocument
 
 	/**
@@ -510,7 +551,7 @@ interface DocumentApi : DocumentBasicFlavourlessApi, DocumentFlavouredApi<Decryp
 	 * @return the id of the patient linked to the document, or empty if the current user can't access any patient id
 	 * of the document.
 	 */
-	suspend fun decryptPatientIdOf(document: Document): Set<String>
+	suspend fun decryptOwningEntityIdsOf(document: Document): Set<String>
 
 	/**
 	 * Create metadata to allow other users to identify the anonymous delegates of a document.

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/DocumentApi.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/DocumentApi.kt
@@ -366,7 +366,7 @@ interface DocumentApi : DocumentBasicFlavourlessApi, DocumentFlavouredApi<Decryp
 	 * @return a document with initialized encryption metadata.
 	 * @throws IllegalArgumentException if base is not null and has a revision or has encryption metadata.
 	 */
-	suspend fun withEncryptionMetadata(
+	suspend fun withEncryptionMetadataLinkedToMessage(
 		base: DecryptedDocument?,
 		message: Message,
 		@DefaultValue("null")
@@ -389,7 +389,7 @@ interface DocumentApi : DocumentBasicFlavourlessApi, DocumentFlavouredApi<Decryp
 	 * @return a document with initialized encryption metadata.
 	 * @throws IllegalArgumentException if base is not null and has a revision or has encryption metadata.
 	 */
-	suspend fun withEncryptionMetadata(
+	suspend fun withEncryptionMetadataLinkedToPatient(
 		base: DecryptedDocument?,
 		patient: Patient,
 		@DefaultValue("null")
@@ -410,7 +410,7 @@ interface DocumentApi : DocumentBasicFlavourlessApi, DocumentFlavouredApi<Decryp
 	 * @return a document with initialized encryption metadata.
 	 * @throws IllegalArgumentException if base is not null and has a revision or has encryption metadata.
 	 */
-	suspend fun withEncryptionMetadata(
+	suspend fun withEncryptionMetadataUnlinked(
 		base: DecryptedDocument?,
 		@DefaultValue("null")
 		user: User? = null,

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DocumentApiImpl.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/api/impl/DocumentApiImpl.kt
@@ -293,7 +293,7 @@ internal class DocumentApiImpl(
 	private val crypto get() = config.crypto
 	private val fieldsToEncrypt get() = config.encryption.document
 
-	override suspend fun withEncryptionMetadata(
+	override suspend fun withEncryptionMetadataLinkedToPatient(
 		base: DecryptedDocument?,
 		patient: Patient,
 		user: User?,
@@ -320,7 +320,7 @@ internal class DocumentApiImpl(
 			autoDelegations = (delegates + user?.autoDelegationsFor(DelegationTag.MedicalInformation).orEmpty()).keyAsLocalDataOwnerReferences(),
 		).updatedEntity
 
-	override suspend fun withEncryptionMetadata(
+	override suspend fun withEncryptionMetadataLinkedToMessage(
 		base: DecryptedDocument?,
 		message: Message,
 		user: User?,
@@ -348,7 +348,7 @@ internal class DocumentApiImpl(
 			autoDelegations = (delegates + user?.autoDelegationsFor(DelegationTag.MedicalInformation).orEmpty()).keyAsLocalDataOwnerReferences(),
 		).updatedEntity
 
-	override suspend fun withEncryptionMetadata(
+	override suspend fun withEncryptionMetadataUnlinked(
 		base: DecryptedDocument?,
 		user: User?,
 		delegates: Map<String, AccessLevel>

--- a/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/DocumentFilters.kt
+++ b/cardinal-sdk/src/commonMain/kotlin/com/icure/cardinal/sdk/filters/DocumentFilters.kt
@@ -6,6 +6,7 @@ import com.icure.cardinal.sdk.crypto.entities.EntityWithEncryptionMetadataStub
 import com.icure.cardinal.sdk.crypto.entities.EntityWithEncryptionMetadataTypeName
 import com.icure.cardinal.sdk.crypto.entities.toEncryptionMetadataStub
 import com.icure.cardinal.sdk.model.Document
+import com.icure.cardinal.sdk.model.Message
 import com.icure.cardinal.sdk.model.Patient
 import com.icure.cardinal.sdk.model.embed.DocumentType
 import com.icure.cardinal.sdk.model.filter.AbstractFilter
@@ -27,7 +28,7 @@ object DocumentFilters {
 	 *
 	 * When using these options the sdk will automatically extract the secret ids from the provided patients and use
 	 * those for filtering.
-	 * If you already have the secret ids of the patient you may instead use [byPatientSecretIdsCreatedForDataOwner].
+	 * If you already have the secret ids of the patient you may instead use [byOwningEntitySecretIdsCreatedForDataOwner].
 	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
@@ -60,6 +61,47 @@ object DocumentFilters {
 	)
 
 	/**
+	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with a specific data owner
+	 * that are linked with one of the provided messages.
+	 * This Options also allows to restrict the documents based on [Document.created]:
+	 * - if the [from] is not null, only the documents where [Document.created] is greater than or equal to [from] will be returned.
+	 * - if the [to] is not null, only the documents where [Document.created] is less than or equal to [to] will be returned.
+	 *
+	 * When using these options the sdk will automatically extract the secret ids from the provided patients and use
+	 * those for filtering.
+	 * If you already have the secret ids of the message you may instead use [byOwningEntitySecretIdsCreatedForDataOwner].
+	 * If the current data owner does not have access to any secret id of one of the provided messages the message will
+	 * simply be ignored.
+	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
+	 *
+	 * These options are sortable. When sorting using these options the documents will be sorted by [Document.created] in ascending or
+	 * descending order according to the value of the [descending] parameter.
+	 *
+	 * @param dataOwnerId a data owner id
+	 * @param messages a list of messages.
+	 * @param from the minimum value for [Document.created] (default: no limit).
+	 * @param to the maximum value for [Document.created] (default: no limit).
+	 * @param descending whether to sort the result in descending or ascending order by [Document.created] (default: ascending).
+	 */
+	@OptIn(InternalIcureApi::class)
+	fun byMessagesCreatedForDataOwner(
+		dataOwnerId: String,
+		messages: List<Message>,
+		@DefaultValue("null")
+		from: Instant? = null,
+		@DefaultValue("null")
+		to: Instant? = null,
+		@DefaultValue("false")
+		descending: Boolean = false
+	): SortableFilterOptions<Document> = ByMessagesCreatedForDataOwner(
+		dataOwnerId = dataOwnerId,
+		messages = messages.map { it.toEncryptionMetadataStub() },
+		from = from,
+		to = to,
+		descending = descending
+	)
+
+	/**
 	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with the current data owner
 	 * that are linked with one of the provided patients.
 	 * This Options also allows to restrict the documents based on [Document.created]:
@@ -68,7 +110,7 @@ object DocumentFilters {
 	 *
 	 * When using these options the sdk will automatically extract the secret ids from the provided patients and use
 	 * those for filtering.
-	 * If you already have the secret ids of the patient you may instead use [byPatientSecretIdsCreatedForSelf].
+	 * If you already have the secret ids of the patient you may instead use [byOwningEntitySecretIdsCreatedForSelf].
 	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
@@ -98,6 +140,44 @@ object DocumentFilters {
 	)
 
 	/**
+	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with the current data owner
+	 * that are linked with one of the provided messages.
+	 * This Options also allows to restrict the documents based on [Document.created]:
+	 * - if the [from] is not null, only the documents where [Document.created] is greater than or equal to [from] will be returned.
+	 * - if the [to] is not null, only the documents where [Document.created] is less than or equal to [to] will be returned.
+	 *
+	 * When using these options the sdk will automatically extract the secret ids from the provided messages and use
+	 * those for filtering.
+	 * If you already have the secret ids of the message you may instead use [byOwningEntitySecretIdsCreatedForSelf].
+	 * If the current data owner does not have access to any secret id of one of the provided messages the message will
+	 * simply be ignored.
+	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
+	 *
+	 * These options are sortable. When sorting using these options the documents will be sorted by [Document.created] in ascending or
+	 * descending order according to the value of the [descending] parameter.
+	 *
+	 * @param messages a list of messages.
+	 * @param from the minimum value for [Document.created] (default: no limit).
+	 * @param to the maximum value for [Document.created] (default: no limit).
+	 * @param descending whether to sort the result in descending or ascending order by [Document.created] (default: ascending).
+	 */
+	@OptIn(InternalIcureApi::class)
+	fun byMessagesCreatedForSelf(
+		messages: List<Message>,
+		@DefaultValue("null")
+		from: Instant? = null,
+		@DefaultValue("null")
+		to: Instant? = null,
+		@DefaultValue("false")
+		descending: Boolean = false
+	): SortableFilterOptions<Document> = ByMessagesCreatedForSelf(
+		messages = messages.map { it.toEncryptionMetadataStub() },
+		from = from,
+		to = to,
+		descending = descending
+	)
+
+	/**
 	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with a specific owner
 	 * that are linked with one of the provided patients through one of the provided secret ids.
 	 * This Options also allows to restrict the documents based on [Document.created]:
@@ -116,7 +196,7 @@ object DocumentFilters {
 	 * @param to the maximum value for [Document.created] (default: no limit).
 	 * @param descending whether to sort the result in descending or ascending order by [Document.created] (default: ascending).
 	 */
-	fun byPatientSecretIdsCreatedForDataOwner(
+	fun byOwningEntitySecretIdsCreatedForDataOwner(
 		dataOwnerId: String,
 		secretIds: List<String>,
 		@DefaultValue("null")
@@ -125,28 +205,34 @@ object DocumentFilters {
 		to: Instant? = null,
 		@DefaultValue("false")
 		descending: Boolean = false
-	): BaseSortableFilterOptions<Document> = ByPatientSecretIdsCreatedForDataOwner(dataOwnerId, secretIds, from, to, descending)
+	): BaseSortableFilterOptions<Document> = ByOwningEntitySecretIdsCreatedForDataOwner(
+		dataOwnerId = dataOwnerId,
+		secretIds = secretIds,
+		from = from,
+		to = to,
+		descending = descending
+	)
 
 	/**
 	 * Options for document filtering which match all documents shared directly (i.e. ignoring hierarchies) with the current data owner
-	 * that are linked with one of the provided patients through one of the provided secret ids.
+	 * that are linked with one of the provided owning entities through one of the provided secret ids.
 	 * This Options also allows to restrict the documents based on [Document.created]:
 	 * - if the [from] is not null, only the documents where [Document.created] is greater than or equal to [from] will be returned.
 	 * - if the [to] is not null, only the documents where [Document.created] is less than or equal to [to] will be returned.
 	 *
-	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
+	 * If the current data owner does not have access to any secret id of one of the provide owning entities the owning entity will
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
 	 * These options are sortable. When sorting using these options the documents will be sorted by [Document.created] in ascending or
 	 * descending order according to the value of the [descending] parameter.
 	 *
-	 * @param secretIds a list of patient secret ids.
+	 * @param secretIds a list of owning entity secret ids.
 	 * @param from the minimum value for [Document.created] (default: no limit).
 	 * @param to the maximum value for [Document.created] (default: no limit).
 	 * @param descending whether to sort the result in descending or ascending order by [Document.created] (default: ascending).
 	 */
-	fun byPatientSecretIdsCreatedForSelf(
+	fun byOwningEntitySecretIdsCreatedForSelf(
 		secretIds: List<String>,
 		@DefaultValue("null")
 		from: Instant? = null,
@@ -154,7 +240,12 @@ object DocumentFilters {
 		to: Instant? = null,
 		@DefaultValue("false")
 		descending: Boolean = false
-	): SortableFilterOptions<Document> = ByPatientSecretIdsCreatedForSelf(secretIds, from, to, descending)
+	): SortableFilterOptions<Document> = ByOwningEntitySecretIdsCreatedForSelf(
+		secretIds = secretIds,
+		from = from,
+		to = to,
+		descending = descending
+	)
 
 	/**
 	 * Options for document filter which match all the documents shared directly (i.e. ignoring hierarchies) with a specific data owner
@@ -162,8 +253,8 @@ object DocumentFilters {
 	 *
 	 * When using these options the sdk will automatically extract the secret ids from the provided patients and use
 	 * those for filtering.
-	 * If you already have the secret ids of the patient you may instead use [byPatientSecretIdsAndTypeForDataOwner].
-	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
+	 * If you already have the secret ids of the patient you may instead use [byOwningEntitySecretIdsAndTypeForDataOwner].
+	 * If the current data owner does not have access to any secret id of one of the provided patients the patient will
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
@@ -183,12 +274,38 @@ object DocumentFilters {
 	)
 
 	/**
+	 * Options for document filter which match all the documents shared directly (i.e. ignoring hierarchies) with a specific data owner
+	 * that are linked with of the provided messages and where [Document.documentType] is equal to [documentType].
+	 *
+	 * When using these options the sdk will automatically extract the secret ids from the provided messages and use
+	 * those for filtering.
+	 * If you already have the secret ids of the message you may instead use [byOwningEntitySecretIdsAndTypeForDataOwner].
+	 * If the current data owner does not have access to any secret id of one of the provided messages the message will
+	 * simply be ignored.
+	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
+	 *
+	 * @param dataOwnerId the id of a data owner.
+	 * @param documentType the document type to search.
+	 * @param messages a list of messages.
+	 */
+	@OptIn(InternalIcureApi::class)
+	fun byMessagesAndTypeForDataOwner(
+		dataOwnerId: String,
+		documentType: DocumentType,
+		messages: List<Message>
+	): FilterOptions<Document> = ByMessagesTypeForDataOwner(
+		dataOwnerId = dataOwnerId,
+		messages = messages.map { it.toEncryptionMetadataStub() },
+		type = documentType
+	)
+
+	/**
 	 * Options for document filter which match all the documents shared directly (i.e. ignoring hierarchies) with the current data owner
 	 * that are linked with of the provided patients and where [Document.documentType] is equal to [documentType].
 	 *
 	 * When using these options the sdk will automatically extract the secret ids from the provided patients and use
 	 * those for filtering.
-	 * If you already have the secret ids of the patient you may instead use [byPatientSecretIdsAndTypeForSelf].
+	 * If you already have the secret ids of the patient you may instead use [byOwningEntitySecretIdsAndTypeForSelf].
 	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
@@ -202,43 +319,73 @@ object DocumentFilters {
 		patients: List<Patient>
 	): FilterOptions<Document> = ByPatientsTypeForSelf(
 		patients = patients.map { it.toEncryptionMetadataStub() },
-		documentType
+		type = documentType
+	)
+
+	/**
+	 * Options for document filter which match all the documents shared directly (i.e. ignoring hierarchies) with the current data owner
+	 * that are linked with of the provided messages and where [Document.documentType] is equal to [documentType].
+	 *
+	 * When using these options the sdk will automatically extract the secret ids from the provided messages and use
+	 * those for filtering.
+	 * If you already have the secret ids of the message you may instead use [byOwningEntitySecretIdsAndTypeForSelf].
+	 * If the current data owner does not have access to any secret id of one of the provide messages the message will
+	 * simply be ignored.
+	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
+	 *
+	 * @param documentType the document type to search.
+	 * @param patients a list of patients.
+	 */
+	@OptIn(InternalIcureApi::class)
+	fun byMessagesAndTypeForSelf(
+		documentType: DocumentType,
+		messages: List<Message>
+	): FilterOptions<Document> = ByMessagesTypeForSelf(
+		messages = messages.map { it.toEncryptionMetadataStub() },
+		type = documentType
 	)
 
 	/**
 	 * Options for document filter which match all the documents shared directly (i.e. ignoring hierarchies) with a specific data owner
-	 * that are linked with of the provided patients through one of the provided secret ids and where [Document.documentType] is equal
+	 * that are linked with of the provided owning entities through one of the provided secret ids and where [Document.documentType] is equal
 	 * to [documentType].
 	 *
-	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
+	 * If the current data owner does not have access to any secret id of one of the provided owning entities the owning entity will
 	 * simply be ignored.
 	 *
 	 * @param dataOwnerId the id of a data owner.
 	 * @param documentType the document type to search.
 	 * @param secretIds a list of patient secret ids.
 	 */
-	fun byPatientSecretIdsAndTypeForDataOwner(
+	fun byOwningEntitySecretIdsAndTypeForDataOwner(
 		dataOwnerId: String,
 		documentType: DocumentType,
 		secretIds: List<String>
-	): FilterOptions<Document> = ByPatientSecretIdsTypeForDataOwner(dataOwnerId, secretIds, documentType)
+	): FilterOptions<Document> = ByOwningEntitySecretIdsTypeForDataOwner(
+		dataOwnerId = dataOwnerId,
+		secretIds = secretIds,
+		type = documentType
+	)
 
 	/**
 	 * Options for document filter which match all the documents shared directly (i.e. ignoring hierarchies) with the current data owner
-	 * that are linked with of the provided patients through one of the provided secret ids and where [Document.documentType] is equal
+	 * that are linked with of the provided owning entities through one of the provided secret ids and where [Document.documentType] is equal
 	 * to [documentType].
 	 *
-	 * If the current data owner does not have access to any secret id of one of the provide patients the patient will
+	 * If the current data owner does not have access to any secret id of one of the provide owning entities the owning entity will
 	 * simply be ignored.
 	 * Note that these may not be used in methods of apis from [CardinalBaseApis].
 	 *
 	 * @param documentType the document type to search.
 	 * @param secretIds a list of patient secret ids.
 	 */
-	fun byPatientSecretIdsAndTypeForSelf(
+	fun byOwningEntitySecretIdsAndTypeForSelf(
 		documentType: DocumentType,
 		secretIds: List<String>
-	): FilterOptions<Document> = ByPatientSecretIdsTypeForSelf(secretIds, documentType)
+	): FilterOptions<Document> = ByOwningEntitySecretIdsTypeForSelf(
+		secretIds = secretIds,
+		type = documentType,
+	)
 
 
 	@Serializable
@@ -246,6 +393,16 @@ object DocumentFilters {
 	internal class ByPatientsCreatedForDataOwner(
 		val dataOwnerId: String,
 		val patients: List<EntityWithEncryptionMetadataStub>,
+		val from: Instant?,
+		val to: Instant?,
+		val descending: Boolean
+	): SortableFilterOptions<Document>
+
+	@Serializable
+	@InternalIcureApi
+	internal class ByMessagesCreatedForDataOwner(
+		val dataOwnerId: String,
+		val messages: List<EntityWithEncryptionMetadataStub>,
 		val from: Instant?,
 		val to: Instant?,
 		val descending: Boolean
@@ -261,7 +418,16 @@ object DocumentFilters {
 	): SortableFilterOptions<Document>
 
 	@Serializable
-	internal class ByPatientSecretIdsCreatedForDataOwner(
+	@InternalIcureApi
+	internal class ByMessagesCreatedForSelf(
+		val messages: List<EntityWithEncryptionMetadataStub>,
+		val from: Instant?,
+		val to: Instant?,
+		val descending: Boolean
+	): SortableFilterOptions<Document>
+
+	@Serializable
+	internal class ByOwningEntitySecretIdsCreatedForDataOwner(
 		val dataOwnerId: String,
 		val secretIds: List<String>,
 		val from: Instant?,
@@ -270,7 +436,7 @@ object DocumentFilters {
 	): BaseSortableFilterOptions<Document>
 
 	@Serializable
-	internal class ByPatientSecretIdsCreatedForSelf(
+	internal class ByOwningEntitySecretIdsCreatedForSelf(
 		val secretIds: List<String>,
 		val from: Instant?,
 		val to: Instant?,
@@ -287,20 +453,35 @@ object DocumentFilters {
 
 	@Serializable
 	@InternalIcureApi
+	internal class ByMessagesTypeForDataOwner(
+		val dataOwnerId: String,
+		val messages: List<EntityWithEncryptionMetadataStub>,
+		val type: DocumentType
+	): FilterOptions<Document>
+
+	@Serializable
+	@InternalIcureApi
 	internal class ByPatientsTypeForSelf(
 		val patients: List<EntityWithEncryptionMetadataStub>,
 		val type: DocumentType
 	): FilterOptions<Document>
 
 	@Serializable
-	internal class ByPatientSecretIdsTypeForDataOwner(
+	@InternalIcureApi
+	internal class ByMessagesTypeForSelf(
+		val messages: List<EntityWithEncryptionMetadataStub>,
+		val type: DocumentType
+	): FilterOptions<Document>
+
+	@Serializable
+	internal class ByOwningEntitySecretIdsTypeForDataOwner(
 		val dataOwnerId: String,
 		val secretIds: List<String>,
 		val type: DocumentType
 	): BaseFilterOptions<Document>
 
 	@Serializable
-	internal class ByPatientSecretIdsTypeForSelf(
+	internal class ByOwningEntitySecretIdsTypeForSelf(
 		val secretIds: List<String>,
 		val type: DocumentType
 	): FilterOptions<Document>
@@ -324,6 +505,16 @@ internal suspend fun mapDocumentFilterOptions(
 			descending = filterOptions.descending
 		)
 	}
+	is DocumentFilters.ByMessagesCreatedForDataOwner -> {
+		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
+		DocumentByDataOwnerPatientDateFilter(
+			dataOwnerId = filterOptions.dataOwnerId,
+			secretPatientKeys = entityEncryptionService.secretIdsOf(null, filterOptions.messages, EntityWithEncryptionMetadataTypeName.Message, null).values.flatten().toSet(),
+			startDate = filterOptions.to,
+			endDate = filterOptions.from,
+			descending = filterOptions.descending
+		)
+	}
 	is DocumentFilters.ByPatientsCreatedForSelf -> {
 		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
 		DocumentByDataOwnerPatientDateFilter(
@@ -334,7 +525,17 @@ internal suspend fun mapDocumentFilterOptions(
 			descending = filterOptions.descending
 		)
 	}
-	is DocumentFilters.ByPatientSecretIdsCreatedForSelf -> {
+	is DocumentFilters.ByMessagesCreatedForSelf -> {
+		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
+		DocumentByDataOwnerPatientDateFilter(
+			dataOwnerId = selfDataOwnerId,
+			secretPatientKeys = entityEncryptionService.secretIdsOf(null, filterOptions.messages, EntityWithEncryptionMetadataTypeName.Message, null).values.flatten().toSet(),
+			startDate = filterOptions.to,
+			endDate = filterOptions.from,
+			descending = filterOptions.descending
+		)
+	}
+	is DocumentFilters.ByOwningEntitySecretIdsCreatedForSelf -> {
 		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
 		DocumentByDataOwnerPatientDateFilter(
 			dataOwnerId = selfDataOwnerId,
@@ -344,7 +545,7 @@ internal suspend fun mapDocumentFilterOptions(
 			descending = filterOptions.descending
 		)
 	}
-	is DocumentFilters.ByPatientSecretIdsCreatedForDataOwner -> DocumentByDataOwnerPatientDateFilter(
+	is DocumentFilters.ByOwningEntitySecretIdsCreatedForDataOwner -> DocumentByDataOwnerPatientDateFilter(
 		dataOwnerId = filterOptions.dataOwnerId,
 		secretPatientKeys = filterOptions.secretIds.toSet(),
 		startDate = filterOptions.to,
@@ -359,6 +560,14 @@ internal suspend fun mapDocumentFilterOptions(
 			documentType = filterOptions.type
 		)
 	}
+	is DocumentFilters.ByMessagesTypeForDataOwner -> {
+		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
+		DocumentByTypeDataOwnerPatientFilter(
+			dataOwnerId = filterOptions.dataOwnerId,
+			secretPatientKeys = entityEncryptionService.secretIdsOf(null, filterOptions.messages, EntityWithEncryptionMetadataTypeName.Message, null).values.flatten().toSet(),
+			documentType = filterOptions.type
+		)
+	}
 	is DocumentFilters.ByPatientsTypeForSelf -> {
 		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
 		DocumentByTypeDataOwnerPatientFilter(
@@ -367,12 +576,20 @@ internal suspend fun mapDocumentFilterOptions(
 			documentType = filterOptions.type
 		)
 	}
-	is DocumentFilters.ByPatientSecretIdsTypeForDataOwner -> DocumentByTypeDataOwnerPatientFilter(
+	is DocumentFilters.ByMessagesTypeForSelf -> {
+		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
+		DocumentByTypeDataOwnerPatientFilter(
+			dataOwnerId = selfDataOwnerId,
+			secretPatientKeys = entityEncryptionService.secretIdsOf(null, filterOptions.messages, EntityWithEncryptionMetadataTypeName.Message, null).values.flatten().toSet(),
+			documentType = filterOptions.type
+		)
+	}
+	is DocumentFilters.ByOwningEntitySecretIdsTypeForDataOwner -> DocumentByTypeDataOwnerPatientFilter(
 		dataOwnerId = filterOptions.dataOwnerId,
 		secretPatientKeys = filterOptions.secretIds.toSet(),
 		documentType = filterOptions.type
 	)
-	is DocumentFilters.ByPatientSecretIdsTypeForSelf -> {
+	is DocumentFilters.ByOwningEntitySecretIdsTypeForSelf -> {
 		filterOptions.ensureNonBaseEnvironment(selfDataOwnerId, entityEncryptionService)
 		DocumentByTypeDataOwnerPatientFilter(
 			dataOwnerId = selfDataOwnerId,

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/api/ByteArrayPayloadTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/api/ByteArrayPayloadTest.kt
@@ -22,9 +22,8 @@ class  ByteArrayPayloadTest : StringSpec({
 		val api = hcpDetails.api(specJob)
 		val hcpUser = api.user.getCurrentUser()
 
-		val newDocument = api.document.withEncryptionMetadata(
+		val newDocument = api.document.withEncryptionMetadataUnlinked(
 			base = DecryptedDocument(id = uuid(), name = uuid()),
-			message = null,
 			user = hcpUser
 		)
 		val createdDocument = api.document.createDocument(newDocument)

--- a/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/api/DocumentTest.kt
+++ b/cardinal-sdk/src/commonTest/kotlin/com/icure/cardinal/sdk/api/DocumentTest.kt
@@ -22,11 +22,10 @@ class DocumentTest : StringSpec({
 	"Should be able to create document and set attachment with chosen uti" {
 		val api = createHcpUser().api(specJob)
 		val doc = api.document.createDocument(
-			api.document.withEncryptionMetadata(
+			api.document.withEncryptionMetadataUnlinked(
 				base = DecryptedDocument(
 					id = defaultCryptoService.strongRandom.randomUUID()
 				),
-				message = null
 			)
 		)
 		val mainUti = "public.plain-text"
@@ -47,11 +46,10 @@ class DocumentTest : StringSpec({
 	"Modifying a document after setting the attachment should preserve the attachment" {
 		val api = createHcpUser().api(specJob)
 		val doc = api.document.createDocument(
-			api.document.withEncryptionMetadata(
+			api.document.withEncryptionMetadataUnlinked(
 				base = DecryptedDocument(
 					id = defaultCryptoService.strongRandom.randomUUID()
 				),
-				message = null
 			)
 		)
 		val textAttachment = Random.Default.nextBytes(32).toHexString()

--- a/python-wrapper/src/commonMain/kotlin/com/icure/cardinal/sdk/py/api/DocumentApi/Declarations.kt
+++ b/python-wrapper/src/commonMain/kotlin/com/icure/cardinal/sdk/py/api/DocumentApi/Declarations.kt
@@ -109,7 +109,7 @@ public fun withEncryptionMetadataBlocking(sdk: CardinalApis, params: String): St
 		kotlin.runCatching {
 	val decodedParams = fullLanguageInteropJson.decodeFromString<WithEncryptionMetadataParams>(params)
 	runBlocking {
-		sdk.document.withEncryptionMetadata(
+		sdk.document.withEncryptionMetadataLinkedToMessage(
 			decodedParams.base,
 			decodedParams.message,
 			decodedParams.user,
@@ -132,7 +132,7 @@ public fun withEncryptionMetadataAsync(
 	val decodedParams = fullLanguageInteropJson.decodeFromString<WithEncryptionMetadataParams>(params)
 	GlobalScope.launch {
 		kotlin.runCatching {
-			sdk.document.withEncryptionMetadata(
+			sdk.document.withEncryptionMetadataLinkedToMessage(
 				decodedParams.base,
 				decodedParams.message,
 				decodedParams.user,

--- a/python-wrapper/src/commonMain/kotlin/com/icure/cardinal/sdk/py/api/DocumentApi/Declarations.kt
+++ b/python-wrapper/src/commonMain/kotlin/com/icure/cardinal/sdk/py/api/DocumentApi/Declarations.kt
@@ -97,7 +97,7 @@ public fun createDocumentAsync(
 @Serializable
 private class WithEncryptionMetadataParams(
 	public val base: DecryptedDocument?,
-	public val message: Message?,
+	public val message: Message,
 	public val user: User? = null,
 	public val delegates: Map<String, AccessLevel> = emptyMap(),
 	public val secretId: SecretIdUseOption =
@@ -687,7 +687,7 @@ public fun decryptPatientIdOfBlocking(sdk: CardinalApis, params: String): String
 		kotlin.runCatching {
 	val decodedParams = fullLanguageInteropJson.decodeFromString<DecryptPatientIdOfParams>(params)
 	runBlocking {
-		sdk.document.decryptPatientIdOf(
+		sdk.document.decryptOwningEntityIdsOf(
 			decodedParams.document,
 		)
 	}
@@ -706,7 +706,7 @@ public fun decryptPatientIdOfAsync(
 	val decodedParams = fullLanguageInteropJson.decodeFromString<DecryptPatientIdOfParams>(params)
 	GlobalScope.launch {
 		kotlin.runCatching {
-			sdk.document.decryptPatientIdOf(
+			sdk.document.decryptOwningEntityIdsOf(
 				decodedParams.document,
 			)
 		}.toPyStringAsyncCallback(SetSerializer(String.serializer()), resultCallback)

--- a/python-wrapper/src/commonMain/kotlin/com/icure/cardinal/sdk/py/filters/DocumentFilters/Declarations.kt
+++ b/python-wrapper/src/commonMain/kotlin/com/icure/cardinal/sdk/py/filters/DocumentFilters/Declarations.kt
@@ -74,7 +74,7 @@ private class ByPatientSecretIdsCreatedForDataOwnerParams(
 public fun byPatientSecretIdsCreatedForDataOwner(params: String): String = kotlin.runCatching {
 	val decodedParams =
 			fullLanguageInteropJson.decodeFromString<ByPatientSecretIdsCreatedForDataOwnerParams>(params)
-	DocumentFilters.byPatientSecretIdsCreatedForDataOwner(
+	DocumentFilters.byOwningEntitySecretIdsCreatedForDataOwner(
 		decodedParams.dataOwnerId,
 		decodedParams.secretIds,
 		decodedParams.from,
@@ -95,7 +95,7 @@ private class ByPatientSecretIdsCreatedForSelfParams(
 public fun byPatientSecretIdsCreatedForSelf(params: String): String = kotlin.runCatching {
 	val decodedParams =
 			fullLanguageInteropJson.decodeFromString<ByPatientSecretIdsCreatedForSelfParams>(params)
-	DocumentFilters.byPatientSecretIdsCreatedForSelf(
+	DocumentFilters.byOwningEntitySecretIdsCreatedForSelf(
 		decodedParams.secretIds,
 		decodedParams.from,
 		decodedParams.to,
@@ -148,7 +148,7 @@ private class ByPatientSecretIdsAndTypeForDataOwnerParams(
 public fun byPatientSecretIdsAndTypeForDataOwner(params: String): String = kotlin.runCatching {
 	val decodedParams =
 			fullLanguageInteropJson.decodeFromString<ByPatientSecretIdsAndTypeForDataOwnerParams>(params)
-	DocumentFilters.byPatientSecretIdsAndTypeForDataOwner(
+	DocumentFilters.byOwningEntitySecretIdsAndTypeForDataOwner(
 		decodedParams.dataOwnerId,
 		decodedParams.documentType,
 		decodedParams.secretIds,
@@ -165,7 +165,7 @@ private class ByPatientSecretIdsAndTypeForSelfParams(
 public fun byPatientSecretIdsAndTypeForSelf(params: String): String = kotlin.runCatching {
 	val decodedParams =
 			fullLanguageInteropJson.decodeFromString<ByPatientSecretIdsAndTypeForSelfParams>(params)
-	DocumentFilters.byPatientSecretIdsAndTypeForSelf(
+	DocumentFilters.byOwningEntitySecretIdsAndTypeForSelf(
 		decodedParams.documentType,
 		decodedParams.secretIds,
 	)

--- a/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/api/DocumentApiJs.kt
+++ b/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/api/DocumentApiJs.kt
@@ -71,7 +71,7 @@ public external interface DocumentApiJs {
 
 	public fun hasWriteAccess(document: DocumentJs): Promise<Boolean>
 
-	public fun decryptPatientIdOf(document: DocumentJs): Promise<Array<String>>
+	public fun decryptOwningEntityIdsOf(document: DocumentJs): Promise<Array<String>>
 
 	public fun createDelegationDeAnonymizationMetadata(entity: DocumentJs, delegates: Array<String>):
 			Promise<Unit>

--- a/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/api/impl/DocumentApiImplJs.kt
+++ b/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/api/impl/DocumentApiImplJs.kt
@@ -624,7 +624,7 @@ internal class DocumentApiImplJs(
 			) { secretId: SecretIdUseOptionJs ->
 				secretIdUseOption_fromJs(secretId)
 			}
-			val result = documentApi.withEncryptionMetadata(
+			val result = documentApi.withEncryptionMetadataLinkedToMessage(
 				baseConverted,
 				messageConverted,
 				userConverted,

--- a/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/api/impl/DocumentApiImplJs.kt
+++ b/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/api/impl/DocumentApiImplJs.kt
@@ -840,10 +840,10 @@ internal class DocumentApiImplJs(
 		result
 	}
 
-	override fun decryptPatientIdOf(document: DocumentJs): Promise<Array<String>> =
+	override fun decryptOwningEntityIdsOf(document: DocumentJs): Promise<Array<String>> =
 			GlobalScope.promise {
 		val documentConverted: Document = document_fromJs(document)
-		val result = documentApi.decryptPatientIdOf(
+		val result = documentApi.decryptOwningEntityIdsOf(
 			documentConverted,
 		)
 		setToArray(

--- a/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/filters/InternalDocumentFiltersObj.kt
+++ b/ts-wrapper/src/jsMain/kotlin/com/icure/cardinal/sdk/js/filters/InternalDocumentFiltersObj.kt
@@ -141,7 +141,7 @@ public object InternalDocumentFiltersObj {
 		) { descending: Boolean ->
 			descending
 		}
-		val result = DocumentFilters.byPatientSecretIdsCreatedForDataOwner(
+		val result = DocumentFilters.byOwningEntitySecretIdsCreatedForDataOwner(
 			dataOwnerIdConverted,
 			secretIdsConverted,
 			fromConverted,
@@ -182,7 +182,7 @@ public object InternalDocumentFiltersObj {
 		) { descending: Boolean ->
 			descending
 		}
-		val result = DocumentFilters.byPatientSecretIdsCreatedForSelf(
+		val result = DocumentFilters.byOwningEntitySecretIdsCreatedForSelf(
 			secretIdsConverted,
 			fromConverted,
 			toConverted,
@@ -244,7 +244,7 @@ public object InternalDocumentFiltersObj {
 				x1
 			},
 		)
-		val result = DocumentFilters.byPatientSecretIdsAndTypeForDataOwner(
+		val result = DocumentFilters.byOwningEntitySecretIdsAndTypeForDataOwner(
 			dataOwnerIdConverted,
 			documentTypeConverted,
 			secretIdsConverted,
@@ -262,7 +262,7 @@ public object InternalDocumentFiltersObj {
 				x1
 			},
 		)
-		val result = DocumentFilters.byPatientSecretIdsAndTypeForSelf(
+		val result = DocumentFilters.byOwningEntitySecretIdsAndTypeForSelf(
 			documentTypeConverted,
 			secretIdsConverted,
 		)


### PR DESCRIPTION
We used to have only Messages as the owning entity of a Document; this PR adds support for Patients as well.
